### PR TITLE
Removed Unnecessary generics?

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,22 @@
+MIT License
+
+Copyright (c) 2020 François Mockers
+Copyright (c) 2021 Jerome Humbert
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -38,7 +38,7 @@ impl Plugin for BasicPlugin {
             // Register a event that can be called from your action handler
             .add_event::<BasicEvent>()
             // The plugin
-            .add_plugin(QuickMenuPlugin::<BasicState, Actions, Screens>::new())
+            .add_plugin(QuickMenuPlugin::<Screens>::new())
             // Some systems
             .add_startup_system(setup)
             .add_system(event_reader);
@@ -88,6 +88,7 @@ enum Screens {
 /// Map from from `Screens` to the actual menu
 impl ScreenTrait for Screens {
     type Action = Actions;
+    type State = BasicState;
     fn resolve(&self, state: &BasicState) -> Menu<Actions, Screens, BasicState> {
         match self {
             Screens::Root => root_menu(state),

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -89,7 +89,7 @@ enum Screens {
 impl ScreenTrait for Screens {
     type Action = Actions;
     type State = BasicState;
-    fn resolve(&self, state: &BasicState) -> Menu<Actions, Screens, BasicState> {
+    fn resolve(&self, state: &BasicState) -> Menu<Screens> {
         match self {
             Screens::Root => root_menu(state),
             Screens::Booleans => boolean_menu(state),
@@ -98,7 +98,7 @@ impl ScreenTrait for Screens {
 }
 
 /// The `root` menu that is displayed first
-fn root_menu(_state: &BasicState) -> Menu<Actions, Screens, BasicState> {
+fn root_menu(_state: &BasicState) -> Menu<Screens> {
     Menu::new(
         "root",
         vec![
@@ -111,7 +111,7 @@ fn root_menu(_state: &BasicState) -> Menu<Actions, Screens, BasicState> {
 }
 
 /// The boolean menu which is accessed from the `Screens::Boolean` entry in the root_menu
-fn boolean_menu(state: &BasicState) -> Menu<Actions, Screens, BasicState> {
+fn boolean_menu(state: &BasicState) -> Menu<Screens> {
     Menu::new(
         "boolean",
         vec![

--- a/examples/custom.rs
+++ b/examples/custom.rs
@@ -53,7 +53,7 @@ impl Plugin for BasicPlugin {
             // Register a event that can be called from your action handler
             .add_event::<BasicEvent>()
             // The plugin
-            .add_plugin(QuickMenuPlugin::<BasicState, Actions, Screens>::with_options(options))
+            .add_plugin(QuickMenuPlugin::<Screens>::with_options(options))
             // Some systems
             .add_startup_system(setup)
             .add_system(event_reader);
@@ -116,6 +116,7 @@ enum Screens {
 /// Map from from `Screens` to the actual menu
 impl ScreenTrait for Screens {
     type Action = Actions;
+    type State = BasicState;
     fn resolve(&self, state: &BasicState) -> Menu<Actions, Screens, BasicState> {
         match self {
             Screens::Root => root_menu(state),

--- a/examples/custom.rs
+++ b/examples/custom.rs
@@ -117,7 +117,7 @@ enum Screens {
 impl ScreenTrait for Screens {
     type Action = Actions;
     type State = BasicState;
-    fn resolve(&self, state: &BasicState) -> Menu<Actions, Screens, BasicState> {
+    fn resolve(&self, state: &BasicState) -> Menu<Screens> {
         match self {
             Screens::Root => root_menu(state),
             Screens::Booleans => boolean_menu(state),
@@ -126,7 +126,7 @@ impl ScreenTrait for Screens {
 }
 
 /// The `root` menu that is displayed first
-fn root_menu(state: &BasicState) -> Menu<Actions, Screens, BasicState> {
+fn root_menu(state: &BasicState) -> Menu<Screens> {
     Menu::new(
         "root",
         vec![
@@ -145,7 +145,7 @@ fn root_menu(state: &BasicState) -> Menu<Actions, Screens, BasicState> {
 }
 
 /// The boolean menu which is accessed from the `Screens::Boolean` entry in the root_menu
-fn boolean_menu(state: &BasicState) -> Menu<Actions, Screens, BasicState> {
+fn boolean_menu(state: &BasicState) -> Menu<Screens> {
     Menu::new(
         "boolean",
         vec![

--- a/examples/settings.rs
+++ b/examples/settings.rs
@@ -163,7 +163,7 @@ mod settings {
     impl ScreenTrait for Screens {
         type Action = Actions;
         type State = CustomState;
-        fn resolve(&self, state: &CustomState) -> Menu<Actions, Screens, CustomState> {
+        fn resolve(&self, state: &CustomState) -> Menu<Screens> {
             match self {
                 Screens::Root => root_menu(state),
                 Screens::Controls => controls_menu(state),
@@ -174,7 +174,7 @@ mod settings {
     }
 
     /// The `root` menu that is displayed first
-    fn root_menu(state: &CustomState) -> Menu<Actions, Screens, CustomState> {
+    fn root_menu(state: &CustomState) -> Menu<Screens> {
         Menu::new(
             "root",
             vec![
@@ -188,7 +188,7 @@ mod settings {
     }
 
     /// This is displayed if the user selects `Sound` in the `root_menu`
-    fn sound_menu(state: &CustomState) -> Menu<Actions, Screens, CustomState> {
+    fn sound_menu(state: &CustomState) -> Menu<Screens> {
         Menu::new(
             "sound",
             vec![
@@ -200,7 +200,7 @@ mod settings {
     }
 
     /// This is displayed if the user selects `Controls` in the `root_menu`
-    fn controls_menu(state: &CustomState) -> Menu<Actions, Screens, CustomState> {
+    fn controls_menu(state: &CustomState) -> Menu<Screens> {
         let mut players: Vec<usize> = state.controls.keys().copied().collect();
         players.sort();
         Menu::new(
@@ -216,7 +216,7 @@ mod settings {
     fn player_controls_menu(
         state: &CustomState,
         player: usize,
-    ) -> Menu<Actions, Screens, CustomState> {
+    ) -> Menu<Screens> {
         let selected_control = state.controls[&player];
         // Get the Keyboards
         let mut entries: Vec<_> = vec![

--- a/examples/settings.rs
+++ b/examples/settings.rs
@@ -69,7 +69,7 @@ mod settings {
                 // Register a event that can be called from your action handler
                 .add_event::<MyEvent>()
                 // The plugin
-                .add_plugin(QuickMenuPlugin::<CustomState, Actions, Screens>::new())
+                .add_plugin(QuickMenuPlugin::<Screens>::new())
                 // Some systems
                 .add_system_set(SystemSet::on_enter(GameState::Settings).with_system(setup_system))
                 .add_system_set(
@@ -107,7 +107,7 @@ mod settings {
     /// into our state
     fn update_gamepads_system(
         gamepads: Res<Gamepads>,
-        menu_state: Option<ResMut<MenuState<CustomState, Actions, Screens>>>,
+        menu_state: Option<ResMut<MenuState<Screens>>>,
     ) {
         let Some(mut menu_state) = menu_state else {
             return
@@ -162,6 +162,7 @@ mod settings {
 
     impl ScreenTrait for Screens {
         type Action = Actions;
+        type State = CustomState;
         fn resolve(&self, state: &CustomState) -> Menu<Actions, Screens, CustomState> {
             match self {
                 Screens::Root => root_menu(state),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -152,7 +152,7 @@ pub trait ScreenTrait: Debug + PartialEq + Eq + Clone + Copy + Hash + Send + Syn
     fn resolve(
         &self,
         state: &<<Self as ScreenTrait>::Action as ActionTrait>::State,
-    ) -> Menu<Self::Action, Self, <<Self as ScreenTrait>::Action as ActionTrait>::State>;
+    ) -> Menu<Self>;
 }
 
 /// The primary state resource of the menu

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -75,29 +75,21 @@ pub use types::{
 ///   }
 /// }
 /// ```
-pub struct QuickMenuPlugin<State, A, S>
+pub struct QuickMenuPlugin<S>
 where
-    State: 'static,
-    A: ActionTrait<State = State> + 'static,
-    S: ScreenTrait<Action = A> + 'static,
+    S: ScreenTrait + 'static,
 {
-    state: std::marker::PhantomData<State>,
-    a: std::marker::PhantomData<A>,
     s: std::marker::PhantomData<S>,
     options: Option<MenuOptions>,
 }
 
-impl<State, A, S> QuickMenuPlugin<State, A, S>
+impl<S> QuickMenuPlugin<S>
 where
-    State: 'static,
-    A: ActionTrait<State = State> + 'static,
-    S: ScreenTrait<Action = A> + 'static,
+    S: ScreenTrait + 'static,
 {
     #[allow(clippy::new_without_default)]
     pub fn new() -> Self {
         Self {
-            state: Default::default(),
-            a: Default::default(),
             s: Default::default(),
             options: None,
         }
@@ -105,19 +97,17 @@ where
 
     pub fn with_options(options: MenuOptions) -> Self {
         Self {
-            state: Default::default(),
-            a: Default::default(),
             s: Default::default(),
             options: Some(options),
         }
     }
 }
 
-impl<State, A, S> Plugin for QuickMenuPlugin<State, A, S>
+impl<State, A ,S> Plugin for QuickMenuPlugin<S>
 where
     State: 'static + Send + Sync,
     A: ActionTrait<State = State> + 'static,
-    S: ScreenTrait<Action = A> + 'static,
+    S: ScreenTrait<Action = A, State = State> + 'static,
 {
     fn build(&self, app: &mut bevy::prelude::App) {
         app.insert_resource(self.options.unwrap_or_default())
@@ -128,15 +118,15 @@ where
             .add_system_set(
                 SystemSet::new()
                     .with_run_criteria(resource_exists::<CleanUpUI>)
-                    .with_system(systems::cleanup_system::<State, A, S>),
+                    .with_system(systems::cleanup_system::<S>),
             )
             .add_system_set(
                 SystemSet::new()
-                    .with_run_criteria(resource_exists::<MenuState<State, A, S>>)
+                    .with_run_criteria(resource_exists::<MenuState<S>>)
                     .with_system(crate::systems::keyboard_input_system)
-                    .with_system(crate::systems::input_system::<State, A, S>)
-                    .with_system(crate::systems::mouse_system::<State, A, S>)
-                    .with_system(crate::systems::redraw_system::<State, A, S>),
+                    .with_system(crate::systems::input_system::<S>)
+                    .with_system(crate::systems::mouse_system::<S>)
+                    .with_system(crate::systems::redraw_system::<S>),
             );
     }
 }
@@ -157,7 +147,8 @@ pub trait ActionTrait: Debug + PartialEq + Eq + Clone + Copy + Hash + Send + Syn
 /// Each Menu / Screen uses this trait to define which menu items lead
 /// to which other screens
 pub trait ScreenTrait: Debug + PartialEq + Eq + Clone + Copy + Hash + Send + Sync {
-    type Action: ActionTrait;
+    type Action: ActionTrait<State = Self::State>;
+    type State: Send + Sync + 'static;
     fn resolve(
         &self,
         state: &<<Self as ScreenTrait>::Action as ActionTrait>::State,
@@ -166,23 +157,19 @@ pub trait ScreenTrait: Debug + PartialEq + Eq + Clone + Copy + Hash + Send + Syn
 
 /// The primary state resource of the menu
 #[derive(Resource)]
-pub struct MenuState<State, A, S>
+pub struct MenuState<S>
 where
-    State: 'static,
-    A: ActionTrait<State = State> + 'static,
-    S: ScreenTrait<Action = A> + 'static,
+    S: ScreenTrait + 'static,
 {
-    menu: NavigationMenu<State, A, S>,
+    menu: NavigationMenu<S>,
     pub initial_render_done: bool,
 }
 
-impl<State, A, S> MenuState<State, A, S>
+impl<S> MenuState<S>
 where
-    State: 'static,
-    A: ActionTrait<State = State> + 'static,
-    S: ScreenTrait<Action = A> + 'static,
+    S: ScreenTrait + 'static,
 {
-    pub fn new(state: State, screen: S, sheet: Option<Stylesheet>) -> Self {
+    pub fn new(state: S::State, screen: S, sheet: Option<Stylesheet>) -> Self {
         Self {
             menu: NavigationMenu::new(state, screen, sheet),
             initial_render_done: false,
@@ -193,12 +180,12 @@ where
     /// Changing something here will cause a re-render in the next frame.
     /// Due to the way bevy works, just getting this reference, without actually performing
     /// a change is enough to cause a re-render.
-    pub fn state_mut(&mut self) -> &mut State {
+    pub fn state_mut(&mut self) -> &mut S::State {
         &mut self.menu.state
     }
 
     /// Can a immutable reference to the state.
-    pub fn state(&self) -> &State {
+    pub fn state(&self) -> &S::State {
         &self.menu.state
     }
 }

--- a/src/navigation_menu.rs
+++ b/src/navigation_menu.rs
@@ -29,11 +29,11 @@ where
     pub(crate) stylesheet: Stylesheet,
 }
 
-impl<State, S> NavigationMenu<S>
+impl<S> NavigationMenu<S>
 where
-    S: ScreenTrait<State = State>,
+    S: ScreenTrait,
 {
-    pub fn new(state: State, root: S, sheet: Option<Stylesheet>) -> Self {
+    pub fn new(state: S::State, root: S, sheet: Option<Stylesheet>) -> Self {
         Self {
             stack: vec![root],
             state,

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,7 +1,7 @@
 use std::borrow::Cow;
 use std::hash::Hash;
 
-use crate::{ActionTrait, ScreenTrait};
+use crate::ScreenTrait;
 use bevy::prelude::*;
 use bevy::render::texture::{CompressedImageFormats, ImageType};
 use bevy::utils::HashMap;
@@ -56,25 +56,21 @@ pub enum NavigationEvent {
 pub struct RedrawEvent;
 
 /// Create a menu with an identifier and a `Vec` of `MenuItem` entries
-pub struct Menu<A, S, State>
+pub struct Menu<S>
 where
-    State: 'static,
-    A: ActionTrait<State = State> + 'static,
-    S: ScreenTrait<Action = A> + 'static,
+    S: ScreenTrait + 'static,
 {
     pub id: WidgetId,
-    pub entries: Vec<MenuItem<State, A, S>>,
+    pub entries: Vec<MenuItem<S>>,
     pub style: Option<Style>,
     pub background: Option<BackgroundColor>,
 }
 
-impl<A, S, State> Menu<A, S, State>
+impl<S> Menu<S>
 where
-    State: 'static,
-    A: ActionTrait<State = State> + 'static,
-    S: ScreenTrait<Action = A> + 'static,
+    S: ScreenTrait + 'static,
 {
-    pub fn new(id: impl Into<WidgetId>, entries: Vec<MenuItem<State, A, S>>) -> Self {
+    pub fn new(id: impl Into<WidgetId>, entries: Vec<MenuItem<S>>) -> Self {
         let id = id.into();
         Self {
             id,
@@ -97,28 +93,26 @@ where
 
 /// Abstraction over MenuItems in a Screen / Menu
 #[allow(clippy::large_enum_variant)]
-pub enum MenuItem<State, A, S>
+pub enum MenuItem<S>
 where
-    A: ActionTrait<State = State>,
-    S: ScreenTrait<Action = A>,
+    S: ScreenTrait,
 {
     Screen(WidgetLabel, MenuIcon, S),
-    Action(WidgetLabel, MenuIcon, A),
+    Action(WidgetLabel, MenuIcon, S::Action),
     Label(WidgetLabel, MenuIcon),
     Headline(WidgetLabel, MenuIcon),
     Image(Handle<Image>, Option<Style>),
 }
 
-impl<State, A, S> MenuItem<State, A, S>
+impl<S> MenuItem<S>
 where
-    A: ActionTrait<State = State>,
-    S: ScreenTrait<Action = A>,
+    S: ScreenTrait,
 {
     pub fn screen(s: impl Into<WidgetLabel>, screen: S) -> Self {
         MenuItem::Screen(s.into(), MenuIcon::None, screen)
     }
 
-    pub fn action(s: impl Into<WidgetLabel>, action: A) -> Self {
+    pub fn action(s: impl Into<WidgetLabel>, action: S::Action) -> Self {
         MenuItem::Action(s.into(), MenuIcon::None, action)
     }
 
@@ -170,10 +164,9 @@ where
     }
 }
 
-impl<State, A, S> std::fmt::Debug for MenuItem<State, A, S>
+impl<S> std::fmt::Debug for MenuItem<S>
 where
-    A: ActionTrait<State = State>,
-    S: ScreenTrait<Action = A>,
+    S: ScreenTrait,
 {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
@@ -196,10 +189,9 @@ where
     None,
 }
 
-impl<A, S, State> Clone for MenuSelection<S>
+impl<S> Clone for MenuSelection<S>
 where
-    A: ActionTrait<State = State>,
-    S: ScreenTrait<Action = A>,
+    S: ScreenTrait,
 {
     fn clone(&self) -> Self {
         match self {
@@ -210,10 +202,9 @@ where
     }
 }
 
-impl<A, S, State> std::fmt::Debug for MenuSelection<S>
+impl<S> std::fmt::Debug for MenuSelection<S>
 where
-    A: ActionTrait<State = State>,
-    S: ScreenTrait<Action = A>,
+    S: ScreenTrait,
 {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
@@ -224,10 +215,9 @@ where
     }
 }
 
-impl<A, S, State> PartialEq for MenuSelection<S>
+impl<S> PartialEq for MenuSelection<S>
 where
-    A: ActionTrait<State = State>,
-    S: ScreenTrait<Action = A>,
+    S: ScreenTrait,
 {
     fn eq(&self, other: &Self) -> bool {
         match (self, other) {

--- a/src/types.rs
+++ b/src/types.rs
@@ -17,14 +17,12 @@ pub struct VerticalMenuComponent(pub &'static str);
 /// Each Button in the UI can be queried via this component in order
 /// to further change the appearance
 #[derive(Component)]
-pub struct ButtonComponent<State, A, S>
+pub struct ButtonComponent<S>
 where
-    State: 'static,
-    A: ActionTrait<State = State> + 'static,
-    S: ScreenTrait<Action = A> + 'static,
+    S: ScreenTrait + 'static,
 {
     pub style: crate::style::StyleEntry,
-    pub selection: MenuSelection<A, S, State>,
+    pub selection: MenuSelection<S>,
     pub menu_identifier: (&'static str, usize),
     pub selected: bool,
 }
@@ -150,7 +148,7 @@ where
         }
     }
 
-    pub(crate) fn as_selection(&self) -> MenuSelection<A, S, State> {
+    pub(crate) fn as_selection(&self) -> MenuSelection<S> {
         match self {
             MenuItem::Screen(_, _, a) => MenuSelection::Screen(*a),
             MenuItem::Action(_, _, a) => MenuSelection::Action(*a),
@@ -185,17 +183,16 @@ where
 }
 
 /// Abstraction over a concrete selection in a screen / menu
-pub enum MenuSelection<A, S, State>
+pub enum MenuSelection<S>
 where
-    A: ActionTrait<State = State>,
-    S: ScreenTrait<Action = A>,
+    S: ScreenTrait,
 {
-    Action(A),
+    Action(S::Action),
     Screen(S),
     None,
 }
 
-impl<A, S, State> Clone for MenuSelection<A, S, State>
+impl<A, S, State> Clone for MenuSelection<S>
 where
     A: ActionTrait<State = State>,
     S: ScreenTrait<Action = A>,
@@ -209,7 +206,7 @@ where
     }
 }
 
-impl<A, S, State> std::fmt::Debug for MenuSelection<A, S, State>
+impl<A, S, State> std::fmt::Debug for MenuSelection<S>
 where
     A: ActionTrait<State = State>,
     S: ScreenTrait<Action = A>,
@@ -223,7 +220,7 @@ where
     }
 }
 
-impl<A, S, State> PartialEq for MenuSelection<A, S, State>
+impl<A, S, State> PartialEq for MenuSelection<S>
 where
     A: ActionTrait<State = State>,
     S: ScreenTrait<Action = A>,

--- a/src/widgets/button.rs
+++ b/src/widgets/button.rs
@@ -4,30 +4,26 @@ use crate::types::{ButtonComponent, MenuAssets, WidgetLabel};
 use crate::{ActionTrait, MenuSelection, ScreenTrait};
 use bevy::prelude::*;
 
-pub struct ButtonWidget<'a, A, S, State>
+pub struct ButtonWidget<'a, S>
 where
-    State: 'static,
-    A: ActionTrait<State = State> + 'static,
-    S: ScreenTrait<Action = A> + 'static,
+    S: ScreenTrait + 'static,
 {
     text: &'a WidgetLabel,
     style: &'a StyleEntry,
     menu_identifier: (&'static str, usize),
-    selection: &'a MenuSelection<A, S, State>,
+    selection: &'a MenuSelection<S>,
     selected: bool,
 }
 
-impl<'a, A, S, State> ButtonWidget<'a, A, S, State>
+impl<'a, S> ButtonWidget<'a, S>
 where
-    State: 'static,
-    A: ActionTrait<State = State> + 'static,
-    S: ScreenTrait<Action = A> + 'static,
+    S: ScreenTrait + 'static,
 {
     pub fn new(
         text: &'a WidgetLabel,
         style: &'a StyleEntry,
         menu_identifier: (&'static str, usize),
-        selection: &'a MenuSelection<A, S, State>,
+        selection: &'a MenuSelection<S>,
         selected: bool,
     ) -> Self {
         Self {
@@ -40,7 +36,7 @@ where
     }
 }
 
-impl<'a, A, S, State> Widget for ButtonWidget<'a, A, S, State>
+impl<'a, A, S, State> Widget for ButtonWidget<'a, S>
 where
     State: 'static,
     A: ActionTrait<State = State> + 'static,

--- a/src/widgets/button.rs
+++ b/src/widgets/button.rs
@@ -10,8 +10,8 @@ where
 {
     text: &'a WidgetLabel,
     style: &'a StyleEntry,
-    menu_identifier: (&'static str, usize),
-    selection: &'a MenuSelection<A, S, State>,
+    menu_identifier: (WidgetId, usize),
+    selection: &'a MenuSelection<S>,
     selected: bool,
 }
 
@@ -23,7 +23,7 @@ where
         text: &'a WidgetLabel,
         style: &'a StyleEntry,
         menu_identifier: (&'static str, usize),
-        selection: &'a MenuSelection<A, S, State>,
+        selection: &'a MenuSelection<S>,
         selected: bool,
     ) -> Self {
         Self {

--- a/src/widgets/button.rs
+++ b/src/widgets/button.rs
@@ -22,7 +22,7 @@ where
     pub fn new(
         text: &'a WidgetLabel,
         style: &'a StyleEntry,
-        menu_identifier: (&'static str, usize),
+        menu_identifier: (WidgetId, usize),
         selection: &'a MenuSelection<S>,
         selected: bool,
     ) -> Self {

--- a/src/widgets/vertical_menu.rs
+++ b/src/widgets/vertical_menu.rs
@@ -146,7 +146,7 @@ where
         id: &'static str,
         items: &'a [MenuItem<State, A, S>],
         selections: &mut Selections,
-    ) -> Option<MenuSelection<A, S, State>> {
+    ) -> Option<MenuSelection<S>> {
         let (mut selectable_index, selectables) = Self::current_selection(id, items, selections);
 
         let mut select_navigation = false;

--- a/src/widgets/vertical_menu.rs
+++ b/src/widgets/vertical_menu.rs
@@ -4,22 +4,21 @@ use crate::{
         MenuAssets, MenuIcon, MenuItem, MenuSelection, NavigationEvent, Selections,
         VerticalMenuComponent, WidgetId,
     },
-    ActionTrait, ScreenTrait,
+    ScreenTrait,
 };
 use bevy::prelude::*;
 
 use super::Widget;
 use super::{ButtonWidget, LabelWidget};
 
-pub struct VerticalMenu<'a, State, A, S>
+pub struct VerticalMenu<'a, S>
 where
-    A: ActionTrait<State = State>,
-    S: ScreenTrait<Action = A>,
+    S: ScreenTrait,
 {
     // // Each menu needs a distinct id
     pub id: WidgetId,
     // The items in the menu
-    pub items: &'a [MenuItem<State, A, S>],
+    pub items: &'a [MenuItem<S>],
     // Our Stylesheet
     pub stylesheet: &'a Stylesheet,
     // Assets
@@ -30,11 +29,9 @@ where
     pub background: Option<&'a BackgroundColor>,
 }
 
-impl<'a, State, A, S> VerticalMenu<'a, State, A, S>
+impl<'a, S> VerticalMenu<'a, S>
 where
-    State: 'static,
-    A: ActionTrait<State = State> + 'static,
-    S: ScreenTrait<Action = A> + 'static,
+    S: ScreenTrait + 'static,
 {
     pub fn build(self, selections: &Selections, builder: &mut ChildBuilder) {
         let VerticalMenu {
@@ -144,7 +141,7 @@ where
     pub fn apply_event(
         event: &NavigationEvent,
         id: WidgetId,
-        items: &'a [MenuItem<State, A, S>],
+        items: &'a [MenuItem<S>],
         selections: &mut Selections,
     ) -> Option<MenuSelection<S>> {
         let (mut selectable_index, selectables) = Self::current_selection(&id, items, selections);
@@ -180,9 +177,9 @@ where
     #[allow(clippy::type_complexity)]
     fn current_selection(
         id: &WidgetId,
-        items: &'a [MenuItem<State, A, S>],
+        items: &'a [MenuItem<S>],
         selections: &Selections,
-    ) -> (usize, Vec<(usize, &'a MenuItem<State, A, S>)>) {
+    ) -> (usize, Vec<(usize, &'a MenuItem<S>)>) {
         let selectables: Vec<_> = items
             .iter()
             .filter(|e| e.is_selectable())


### PR DESCRIPTION
I Have changed the Generic Types that Screens now need to know State the Screen::Actions::State must be the same as the Screens state. this allowed for a large reduction in generic parsing. Since All Required types and be inferred by just passing in a Screen. I'm not the best with rust and its generics so just let me know if there was a reason you declared all three each time.